### PR TITLE
Updated to work with 1.9, and added rudimental read-table support.

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,21 +25,73 @@
        cause the reader to call =(f stream \[)= when it encounters
        =#[=.
 
+  There are multiple convenience macros to aid in unscrewing the 
+  LispReader:
+  
+   - =(with-macro-character character function & body)= :: Associates a
+       reader-macro with =character=, where =function= has the
+       signature =(fn [stream character opts pending-forms] ...)=.
+       
+       Evaluates body in the context of an altered read-table.
+
+   - =(set-dispatch-macro-character character function)= :: Associates
+       a dispatch-macro with =character=, where =function= has the
+       signature =(fn [stream character opts pending-forms] ...)=.
+       
+       Dispatch-macros are distinguished from reader-macros in that
+       they are activated by the dispatch prefix =#=; issuing
+       e.g. =(set-dispatch-macro-character \[ f)=, therefore, will
+       cause the reader to call =(f stream \[)= when it encounters
+       =#[=.
+	
+       Evaluates body in the context of an altered read-table.
+
+  Notably, the LispReader in clojure (and hence most reader functions) 
+  take 4 args: =[reader quote opts pending-forms]=.  Where possible,
+  we've limited the API to use the first two (ala Common Lisp).
+  The =opts= and =pending-forms= args are related to conditional 
+  compilation, and currently aren't a concern, other than the 
+  arity they introduce to reader functions.  
+
   To define a reader macro, for instance, that reverses strings; try:
 
-  #+BEGIN_QUOTE
   #+BEGIN_SRC clojure
-    (use '[clojure.string :only (reverse)])
-    
+  (def reversed-string-reader
+    (fn [reader quote opts pending-forms]
+      (clojure.string/reverse (macro-read-string  reader quote opts pending-forms))))
+  
+  (def testdata
+    "\"Hello!  This is a string of text, hopefully it's
+     sdrawkcab\"")
+
+  (with-macro-character \" reversed-string-reader
+    (read-string testdata))
+
+  "backwards     \ns'ti yllufepoh ,txet fo gnirts a si sihT  !olleH"
+  #+END_SRC
+
+  There's a convenient with-read-table function to alter 
+  the read-table (currently does not target dispatch macros):
+
+  
+  #+BEGIN_SRC clojure        
     (set-macro-character \"
-     (fn [reader quote]
-       (reverse (macro-read-string reader quote))))
-    
+     (fn [reader quote _ _]
+       (clojure.string/reverse (macro-read-string reader quote))))    
     (println "hello, reader macros")
     => sorcam redaer ,olleh
   #+END_SRC
-  #+END_QUOTE
+  
 
+  Finally, if everything blows up and you don't
+  want to remain in a reader-macroed world anymore,
+  you can get back the default read table by:
+  
+  
+  #+BEGIN_SRC clojure
+  (reset-read-tables!)
+  #+END_SRC
+  
   We've also exposed a few utility functions from
   =clojure.lang.LispReader= to help extract things from readers:
 
@@ -70,11 +122,125 @@
   Add the following to your dependencies in =project.clj=:
 
   #+BEGIN_SRC clojure
-    [reader-macros "1.0.1"]
+    [reader-macros "1.0.2"]
   #+END_SRC
 
   and use it followingly:
 
   #+BEGIN_SRC clojure
+    (require '[reader-macros.core :refer :all])
+    ;;or, deprecated
     (use 'reader-macros.core)
   #+END_SRC
+
+* More Examples
+  
+ We can define simple readers as name functions, then use them:
+ #+BEGIN_SRC clojure
+ (def reversed-string-reader
+    (fn [reader quote opts pending-forms]
+      (clojure.string/reverse (macro-read-string  reader quote opts pending-forms))))
+
+  (def testdata
+    "\"Hello!  This is a string of text, hopefully it's
+     sdrawkcab\"")
+  (with-macro-character \" reversed-string-reader
+    (read-string testdata))
+  ;;"backwards     \ns'ti yllufepoh ,txet fo gnirts a si sihT  !olleH"
+  #+END_SRC
+ Let's mess with lists by reversing the order in which they're
+ supposed to be read!
+ #+BEGIN_SRC clojure
+  (def reversed-list-reader
+    (fn [reader quote opts pending-forms]
+      (reverse (macro-read-list  reader quote opts pending-forms))))
+
+  (def testlist
+    "(a b c d)")
+  
+  (with-macro-character \( reversed-list-reader
+    (read-string testlist))
+  ;;(d c b a)
+  #+END_SRC
+
+  For reading generic collections, we can use read-dimilited-list,
+  which will return a vector by default. Maybe we'll rename it 
+  in the future to conform more closely with the LispReader.
+  For now, you can coerce the result since vectors support the
+  seq abstraction.  
+  
+  This example merely parses lists using the aforementioned
+  helper function:
+ 
+  #+BEGIN_SRC clojure
+  (def read-list (fn [reader quote opts pending-forms]
+      (seq (read-delimited-list \) reader false))))
+
+  (with-macro-character \( read-list
+    (read-string testlist))
+  ;;(a b c d)
+  #+END_SRC
+
+ For completeness, we can read vectors (or anything) 
+ just as easily:
+ #+BEGIN_SRC clojure
+ (def read-vector (fn [reader quote opts pending-forms]
+      (vec (read-delimited-list \] reader false))))
+  
+ (def testvector
+      "[a b c d]")
+ (with-macro-character \[ read-vector
+    (read-string testvector))
+ ;;[a b c d]
+ #+END_SRC
+
+ Now onto the fun!
+ Let's change the semantics of reading 
+ and randomly change vectors into other data 
+ structures...
+ #+BEGIN_SRC clojure
+  ;;maybe your vector is "really"
+  ;;a sequence or a set!  Let the reader decide!
+  (def nondeterministic-reader
+    (fn [reader quote opts pending-forms]
+      (let [stuff (read-delimited-list \] reader false)]
+        (case (rand-nth [:vector :list :set])
+          :vector   (vec stuff)
+          :list      (into '() stuff)
+          (set stuff)))))
+
+  (with-macro-character \[ nondeterministic-reader 
+    (read-string testvector))
+  ;;#{a c b d} ;you may get a list or a vector!
+
+  ;;run it many times to see the spread...
+  (with-macro-character \[ nondeterministic-reader 
+    (frequencies (repeatedly 1000 #(read-string testvector))))
+  ;;{(d c b a) 332, [a b c d] 323, #{a c b d} 345}
+  #+END_SRC
+
+  Finally, let's combine our changes to both readers 
+  into a new read-table that's convenient to use:
+  #+BEGIN_SRC clojure
+  (def string-vector "[\"hello\" \"world\" :a :b :c]")
+
+  (defn wierd-clojure!
+    ([txt]
+  ;;tie it all together with a read-table that jacks
+  ;;everything up!
+    (with-read-table {\" reversed-string-reader
+                      \[ nondeterministic-reader}
+      (read-string txt)))
+    ([] (wierd-clojure! string-vector)))
+
+  ;;reader-macros.core> (wierd-clojure!)
+  ;; (:c :b :a "dlrow" "olleh")
+  ;; reader-macros.core> (wierd-clojure!)
+  ;; ["olleh" "dlrow" :a :b :c]
+  ;; reader-macros.core> (wierd-clojure!)
+  ;; #{:c "dlrow" :b "olleh" :a}
+  ;; reader-macros.core> (wierd-clojure!)
+  ;; (:c :b :a "dlrow" "olleh")
+  ;; reader-macros.core> (wierd-clojure!)
+  ;; ["olleh" "dlrow" :a :b :c]
+     #+END_SRC

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,4 @@
-(defproject reader-macros "1.0.1"
+(defproject reader-macros "1.0.2"
   :description "Common Lisp style reader macros"
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [lambda "1.0.2"]
-                 [cadr "1.0.3"]
-                 [useful "0.7.5"]]
-  :dev-dependencies [[debug "1.0.1"]
-                     [add-classpath "1.0.3"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]]
   :url "https://github.com/klutometis/reader-macros")

--- a/src/reader_macros/core.clj
+++ b/src/reader_macros/core.clj
@@ -1,104 +1,230 @@
 (ns reader-macros.core
-  (:use [cadr :only (car cdr)]
-        [lambda.core :only (λ)]
-        [clojure.string :only (lower-case join)])
+  (:use    [clojure.string :only [lower-case join]])
   (:import (clojure.lang LispReader
                          LispReader$WrappingReader)))
 
-;;;; Make the translation tables accessible.
+;; Make the translation tables accessible.
+(def macros
+  (let [m (.getDeclaredField LispReader "macros")
+        _ (.setAccessible macros true)]
+    (.get macros nil)))
 
-(let [macros (.getDeclaredField LispReader "macros")]
-  (.setAccessible macros true)
-  (let [macros (.get macros nil)]
-    (def set-macro-character
-      (λ [character read]
-        (aset macros (int character) read)))
+(def +default-macros+ (aclone macros))
 
-    (def get-macro-character
-      (λ [character]
-        (aget macros (int character))))))
+(defn set-macro-character [character read]
+  (aset macros (int character) read))
 
-(let [dispatch-macros (.getDeclaredField LispReader "dispatchMacros")]
-  (.setAccessible dispatch-macros true)
-  (let [dispatch-macros (.get dispatch-macros nil)]
-    (def set-dispatch-macro-character
-      (λ [character read]
-        (aset dispatch-macros (int character) read)))
+(defn get-macro-character
+  [character]
+  (aget macros (int character)))
 
-    (def get-dispatch-macro-character
-      (λ [character]
-        (aget dispatch-macros (int character))))))
+(defmacro with-macro-character [character read & body]
+  `(let [char# ~character
+         read#     ~read
+         original# (get-macro-character char#)]
+     (try (do (set-macro-character char# read#)
+              ~@body)
+          (finally (set-macro-character char# original#)))))
+
+(def lisp-readers
+  (->> (seq macros)
+       (map-indexed (fn [idx r] (when r [(char idx)  (str r)])))
+       (filter identity)
+       (into {})))
+
+(def dispatch-macros
+  (let [dm (.getDeclaredField LispReader "dispatchMacros")
+        _  (.setAccessible dm true)]
+    (.get dm nil)))
+
+(def +default-dispatch-macros+ (aclone dispatch-macros))
+
+(defn set-dispatch-macro-character  [character read]
+  (aset dispatch-macros (int character) read))
+
+(defn get-dispatch-macro-character [character]
+  (aget dispatch-macros (int character)))
+
+(def dispatch-readers
+  (->> (seq dispatch-macros)
+       (map-indexed (fn [idx r] (when r [(char idx)  (str r)])))
+       (filter identity)
+       (into {})))
+
+(defmacro with-dispatch-macro-character [character read & body]
+  `(let [char# ~character
+         read#     ~read
+         original# (get-dispatch-macro-character char#)]
+     (try (do (set-dispatch-macro-character char# read#)
+              ~@body)
+          (finally (set-dispatch-macro-character char# original#)))))
+
+
+(defn reset-read-tables!
+  "Undo all the damage we've wrought!"
+  []
+  (doseq [[c r] (map-indexed vector +default-macros+)]
+    (set-macro-character c r))
+  (doseq [[c r] (map-indexed vector +default-dispatch-macros+)]
+    (set-dispatch-macro-character c r)))
 
 ;;;; Dynamically define convenience functions.
+(defn class->predicates [class]
+  (map lower-case (drop-last (re-seq #"[A-Z][a-z]+" class))))
 
-(def class->predicates
-  (λ [class]
-    (map lower-case (drop-last (re-seq #"[A-Z][a-z]+" class)))))
+(defn class->read-class [class]
+  (symbol (format "macro-read-%s" (join "-" (class->predicates class)))))
 
-(def class->read-class
-  (λ [class]
-    (symbol (format "macro-read-%s" (join "-" (class->predicates class))))))
-
-(def nullary-constructor
-  (λ [class]
-    (loop [constructors (into '() (:declaredConstructors (bean class)))]
-      (if (empty? constructors)
-        false
-        (let [constructor (car constructors)]
-          (if (zero? (count (:parameterTypes (bean constructor))))
-            constructor
-            (recur (cdr constructors))))))))
+(defn nullary-constructor [class]
+  (loop [constructors (into '() (:declaredConstructors (bean class)))]
+    (if (empty? constructors)
+      false
+      (let [constructor (first constructors)]
+        (if (zero? (count (:parameterTypes (bean constructor))))
+          constructor
+          (recur (rest constructors)))))))
 
 (def nullary-constructor?
   #(and (nullary-constructor %) true))
-
+    
+;;no longer nullary?
 (def nullary-readers
-  (map (λ [class]
+  (map (fn [class]
          {:class (symbol (.getName class))
           :constructor (nullary-constructor class)
           :read-class (class->read-class (.getSimpleName class))})
-       (filter (λ [class]
+       (filter (fn [class]
                  (and (re-find #"Reader$" (.getSimpleName class))
                       (nullary-constructor? class)))
                (into '() (:declaredClasses (bean LispReader))))))
 
+;;these are no longer nullary...
+;;reads take the form
+;;:: Object reader, Object doublequote, Object opts, Object pendingForms
+
 ;;; Gather a list of these somehow for a dynamic API, or can we do
 ;;; some namespace-tricks?
 (defmacro def-read-macros []
-  `(do ~@(map (λ [{class :class
-                   constructor :constructor
-                   read-class :read-class}]
+  `(do ~@(map (fn [{class       :class
+                    constructor :constructor
+                    read-class  :read-class}]
                 `(let [constructor# (nullary-constructor ~class)]
                    (.setAccessible constructor# true)
                    (let [class-reader# (.newInstance constructor# nil)]
-                     (def ~read-class
-                       (λ [reader# character#]
-                         (.invoke class-reader# reader# character#))))))
+                     (defn ~read-class
+                       ([reader# character# opts# pendingforms#]
+                        (.invoke class-reader# reader# character# opts# pendingforms#))
+                       ([reader# character#]
+                        (~read-class reader# character# ~'+default-opts+ nil))))))
               nullary-readers)))
 
 (def-read-macros)
 
 ;;; Couple of unary exceptions
 (let [macro-deref-reader (LispReader$WrappingReader. 'deref)]
-  (def macro-read-deref
-    (λ [reader character]
-      (.invoke macro-deref-reader reader character))))
+  (defn macro-read-deref [reader character opts pending-forms]
+    (.invoke macro-deref-reader reader character opts pending-forms)))
 
 (let [macro-quote-reader (LispReader$WrappingReader. 'quote)]
-  (def macro-read-quote
-    (λ [reader character]
-      (.invoke macro-quote-reader reader character))))
+  (defn macro-read-quote [reader character opts pending-forms]
+    (.invoke macro-quote-reader reader character opts pending-forms)))
 
 ;;;; Some more utility functions from LispReader
+(def +default-opts+  {:features #{"clj"}
+                      :eofthrow :eof})
 
-(def read-delimited-list
-  (λ [delimiter reader recursive?]
-    (LispReader/readDelimitedList delimiter reader recursive?)))
+(defn read-delimited-list
+  "Interestingly enough, this returns a vector.  Clojure's reader
+   uses vector's internally, likely because they're simpler to conj onto?"
+  ([delimiter reader recursive? opts pending-forms]
+   (LispReader/readDelimitedList delimiter reader recursive? opts pending-forms))
+  ([delimiter reader recursive?]
+   (read-delimited-list delimiter reader recursive? +default-opts+ nil)))
 
-;;; We'd have to make this one accessible.
-;; (def read-unicode-char
-;;     (λ
-;;       ([reader character base length exact?]
-;;          (LispReader/readUnicodeChar reader character base length exact?))
-;;       ([token offset length base]
-;;          (LispReader/readUnicodeChar token offset length base))))
+(defmacro with-read-table
+  [read-table & body]
+  (if-let [bind (first (seq read-table))]
+    (let [[k v] bind]
+    `(with-macro-character
+       ~k ~v
+       (with-read-table ~(dissoc read-table k)
+         ~@body)))
+     `(do ~@body)))
+
+
+
+(comment
+  ;;examples
+  ;;reversed strings from blog...
+  (def reversed-string-reader
+    (fn [reader quote opts pending-forms]
+      (clojure.string/reverse (macro-read-string  reader quote opts pending-forms))))
+
+  (def testdata
+    "\"Hello!  This is a string of text, hopefully it's
+     sdrawkcab\"")
+  (with-macro-character \" reversed-string-reader
+    (read-string testdata))
+  
+  (def reversed-list-reader
+    (fn [reader quote opts pending-forms]
+      (reverse (macro-read-list  reader quote opts pending-forms))))
+
+  (def testlist
+    "(a b c d)")
+  
+  (with-macro-character \( reversed-list-reader
+    (read-string testlist))
+
+  (def read-list (fn [reader quote opts pending-forms]
+      (seq (read-delimited-list \) reader false))))
+
+  (with-macro-character \( read-list
+    (read-string testlist))
+
+ (def read-vector (fn [reader quote opts pending-forms]
+      (vec (read-delimited-list \] reader false))))
+  
+  (def testvector
+      "[a b c d]")
+
+  ;;maybe your vector is "really"
+  ;;a sequence or a set!  Let the reader decide!
+  (def nondeterministic-reader
+    (fn [reader quote opts pending-forms]
+      (let [stuff (read-delimited-list \] reader false)]
+        (case (rand-nth [:vector :list :set])
+          :vector   (vec stuff)
+          :list      (into '() stuff)
+          (set stuff)))))
+
+  (with-macro-character \[ nondeterministic-reader 
+    (read-string testvector))
+
+  (with-macro-character \[ nondeterministic-reader 
+    (frequencies (repeatedly 1000 #(read-string testvector))))
+  ;;{[a b c d] 681, #{a c b d} 319}
+
+  (def string-vector "[\"hello\" \"world\" :a :b :c]")
+
+  (defn wierd-clojure!
+    ([txt]
+  ;;tie it all together with a read-table that jacks
+  ;;everything up!
+    (with-read-table {\" reversed-string-reader
+                      \[ nondeterministic-reader}
+      (read-string txt)))
+    ([] (wierd-clojure! string-vector)))
+
+;;reader-macros.core> (wierd-clojure!)
+;; (:c :b :a "dlrow" "olleh")
+;; reader-macros.core> (wierd-clojure!)
+;; ["olleh" "dlrow" :a :b :c]
+;; reader-macros.core> (wierd-clojure!)
+;; #{:c "dlrow" :b "olleh" :a}
+;; reader-macros.core> (wierd-clojure!)
+;; (:c :b :a "dlrow" "olleh")
+;; reader-macros.core> (wierd-clojure!)
+;; ["olleh" "dlrow" :a :b :c]
+  
+)


### PR DESCRIPTION
As a result of r/clojure discussion, I found it desirable to update your yeoman work on hacking reader macros onto Clojure.

My updates add support for 1.9 (probably beyond....), along with convenience functions for lexically overriding the read-table, resetting the read-table, and defining custom read-tables (currently only for non-dispatch macros, but that's a trivial extension).

I also updated the docs, along with examples.