### PR TITLE
fix "No matching method found: setAccessible"

### DIFF
--- a/src/reader_macros/core.clj
+++ b/src/reader_macros/core.clj
@@ -5,9 +5,9 @@
 
 ;; Make the translation tables accessible.
 (def macros
-  (let [m (.getDeclaredField LispReader "macros")
-        _ (.setAccessible macros true)]
-    (.get macros nil)))
+  (let [field (.getDeclaredField LispReader "macros")]
+    (.setAccessible field true)
+    (.get field nil)))
 
 (def +default-macros+ (aclone macros))
 


### PR DESCRIPTION
Probably that was just a typo: `.setAccessible()` method was called on the `macro` var, not the `Field()` object as intented.

I fixed that, and also re-named `m` to `field` to manifest that this is an instance of `java.lang.reflect.Field`.